### PR TITLE
Changes made for consensus assignment pipeline

### DIFF
--- a/MutationTime.R
+++ b/MutationTime.R
@@ -113,7 +113,7 @@ mergeClusters <- function(clusters, deltaFreq=0.05){
 #' 
 #' @author mg14
 #' @export
-defineMcnStates <- function(bb, clusters, purity, gender='female', isWgd= FALSE){
+defineMcnStates <- function(bb, clusters, purity, gender='female', isWgd= FALSE, deltaFreq=0.05){
 	P <- vector(mode='list', length(bb))
 	uniqueBB <- unique(bb)
 	overlaps <- findOverlaps(uniqueBB, bb)
@@ -137,7 +137,7 @@ defineMcnStates <- function(bb, clusters, purity, gender='female', isWgd= FALSE)
 	
 	power.c <- rep(0, nrow(clusters))
 	
-	deltaFreq <- 0.05 # merge clusters withing deltaFreq
+	#deltaFreq <- 0.05 # merge clusters withing deltaFreq
 	
 	
 	for( i in seq_along(uniqueBB)){
@@ -265,10 +265,10 @@ defineMcnStates <- function(bb, clusters, purity, gender='female', isWgd= FALSE)
 #' 
 #' @author mg14
 #' @export
-computeMutCn <- function(vcf, bb, clusters, purity, gender='female', isWgd= FALSE, xmin=3, rho=0, n.boot=200){
+computeMutCn <- function(vcf, bb, clusters, purity, gender='female', isWgd= FALSE, xmin=3, rho=0, n.boot=200, deltaFreq=deltaFreq){
 	n <- nrow(vcf)
 	D <- DataFrame(MutCN=rep(NA,n), MutDeltaCN=rep(NA,n), MajCN=rep(NA,n), MinCN=rep(NA,n), MajDerCN=rep(NA,n), MinDerCN=rep(NA,n), CNF=rep(NA,n), CNID =as(vector("list", n),"List"), pMutCN=rep(NA,n), pGain=rep(NA,n),pSingle=rep(NA,n),pSub=rep(NA,n), pAllSubclones=as(vector(mode="list",n),"List"), pMutCNTail=rep(NA,n))	
-	P <- defineMcnStates(bb,clusters, purity, gender, isWgd)
+	P <- defineMcnStates(bb,clusters, purity, gender, isWgd, deltaFreq=deltaFreq)
 	if(n==0)
 		return(list(D=D, P=P))
 	


### PR DESCRIPTION
Default functionality remains the same. I've merged the changes made for the consensus mutation assignment pipeline, which either add data to the output or have optional flags which are turned off by default.

* Updated loadBB to round or discard subclonal copy number (to make MutationTimer only consider its given mutation cluster locations)
* Added assignmnent probs to all clusters and allele counts to computeMcn output